### PR TITLE
add explicit ack path introspection to mock server

### DIFF
--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -1181,6 +1181,107 @@ def create_app(user_ctx=None):
                 }
             )
 
+        if "__type(" in body["query"]:
+            return json.dumps(
+                {
+                    "data": {
+                        "__type": {
+                            "inputFields": [
+                                {
+                                    "name": "name",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "groupName",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "displayName",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "notes",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "description",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "sweep",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "id",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "framework",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "config",
+                                    "type": {"name": "JSONString", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "summaryMetrics",
+                                    "type": {"name": "JSONString", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "commit",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "state",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "host",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "debug",
+                                    "type": {"name": "Boolean", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "entityName",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "modelName",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "jobProgram",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "jobRepo",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "jobType",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "tags",
+                                    "type": {"name": None, "kind": "LIST"},
+                                },
+                                {
+                                    "name": "runQueueItemId",
+                                    "type": {"name": "ID", "kind": "SCALAR"},
+                                },
+                                {
+                                    "name": "clientMutationId",
+                                    "type": {"name": "String", "kind": "SCALAR"},
+                                },
+                            ]
+                        }
+                    }
+                }
+            )
+        
+
         print("MISSING QUERY, add me to tests/mock_server.py", body["query"])
         error = {"message": "Not implemented in tests/mock_server.py", "body": body}
         return json.dumps({"errors": [error]})

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -565,8 +565,8 @@ def create_app(user_ctx=None):
                         "outOfDate": ctx.get("out_of_date", False),
                         "latestVersionString": str(ctx.get("latest_version", "0.9.42")),
                     },
-                }
-            }
+                    "exposesExplicitRunQueueAckPath": True
+                }            }
 
             if ctx["empty_query"]:
                 server_info["serverInfo"].pop("latestLocalVersionInfo")
@@ -1180,107 +1180,6 @@ def create_app(user_ctx=None):
                     }
                 }
             )
-
-        if "__type(" in body["query"]:
-            return json.dumps(
-                {
-                    "data": {
-                        "__type": {
-                            "inputFields": [
-                                {
-                                    "name": "name",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "groupName",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "displayName",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "notes",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "description",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "sweep",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "id",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "framework",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "config",
-                                    "type": {"name": "JSONString", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "summaryMetrics",
-                                    "type": {"name": "JSONString", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "commit",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "state",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "host",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "debug",
-                                    "type": {"name": "Boolean", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "entityName",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "modelName",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "jobProgram",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "jobRepo",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "jobType",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "tags",
-                                    "type": {"name": None, "kind": "LIST"},
-                                },
-                                {
-                                    "name": "runQueueItemId",
-                                    "type": {"name": "ID", "kind": "SCALAR"},
-                                },
-                                {
-                                    "name": "clientMutationId",
-                                    "type": {"name": "String", "kind": "SCALAR"},
-                                },
-                            ]
-                        }
-                    }
-                }
-            )
-        
 
         print("MISSING QUERY, add me to tests/mock_server.py", body["query"])
         error = {"message": "Not implemented in tests/mock_server.py", "body": body}

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -565,8 +565,9 @@ def create_app(user_ctx=None):
                         "outOfDate": ctx.get("out_of_date", False),
                         "latestVersionString": str(ctx.get("latest_version", "0.9.42")),
                     },
-                    "exposesExplicitRunQueueAckPath": True
-                }            }
+                    "exposesExplicitRunQueueAckPath": True,
+                }
+            }
 
             if ctx["empty_query"]:
                 server_info["serverInfo"].pop("latestLocalVersionInfo")


### PR DESCRIPTION
This PR adds  the additional server info item exposed by https://github.com/wandb/core/pull/7903/files#diff-ea407d324fa53b1c00778a5a41013682c7cdc1de7eeabaec83d993095b1be95fR556 and used by https://github.com/wandb/client/pull/2374 to yea for consistentcy and to fix the CI for the client PR