### PR TITLE
Put `exposesExplicitRunQueueAckPath` in the correct place and bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.7.16",
+    version="0.7.17",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -565,7 +565,6 @@ def create_app(user_ctx=None):
                         "outOfDate": ctx.get("out_of_date", False),
                         "latestVersionString": str(ctx.get("latest_version", "0.9.42")),
                     },
-                    "exposesExplicitRunQueueAckPath": True,
                 }
             }
 
@@ -584,7 +583,12 @@ def create_app(user_ctx=None):
                     {
                         "data": {
                             "QueryType": {"fields": [{"name": "serverInfo"},]},
-                            "ServerInfoType": {"fields": [{"name": "cliVersionInfo"},]},
+                            "ServerInfoType": {
+                                "fields": [
+                                    {"name": "cliVersionInfo"},
+                                    {"name": "exposesExplicitRunQueueAckPath"},
+                                ]
+                            },
                         }
                     }
                 )
@@ -597,6 +601,7 @@ def create_app(user_ctx=None):
                             "fields": [
                                 {"name": "cliVersionInfo"},
                                 {"name": "latestLocalVersionInfo"},
+                                {"name": "exposesExplicitRunQueueAckPath"},
                             ]
                         },
                     }


### PR DESCRIPTION
In #22 I added `exposesExplicitRunQueueAckPath` to the mock server but returned in from the `Viewer` graphql query instead of the mock `ProbeServerInfo` query. I updated this in the corresponding client PR https://github.com/wandb/client/pull/2374 and bumped the version here to 0.7.17 