### PR TITLE
release 0.7.27; update mock server with runqueue acking logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.7.26",
+    version="0.7.27",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -70,6 +70,7 @@ def default_ctx():
         "run_ids": [],
         "file_names": [],
         "emulate_artifacts": None,
+        "item_acked": False,
         "run_state": "running",
         "run_queue_item_check_count": 0,
         "return_jupyter_in_run_info": False,
@@ -717,6 +718,7 @@ def create_app(user_ctx=None):
                                             "args": {
                                                 "a": {"value": ctx["n_sweep_runs"]}
                                             },
+                                            "runqueue_item_id": f"1jfskn2z",
                                         }
                                     ]
                                 )
@@ -815,6 +817,8 @@ def create_app(user_ctx=None):
                 response["data"]["upsertBucket"]["bucket"][
                     "sweepName"
                 ] = "test-sweep-id"
+            if body["variables"].get("runQueueItemId") == "1jfskn2z":
+                ctx["item_acked"] = True
             return json.dumps(response)
         if "mutation DeleteRun(" in body["query"]:
             return json.dumps({"data": {}})
@@ -2000,6 +2004,10 @@ class ParseCTX(object):
         for k, v in items.items():
             d[k] = getattr(self, v)
         return d
+
+    @property
+    def item_acked(self):
+        return self._ctx.get("item_acked")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Syncs the mock server with https://github.com/wandb/client/pull/2804/commits/cffbbf47f8ef5b92e80e495f9f263aa77e540f43.

Adds logic for handling explicit run queue ack path to mock server 