### PR TITLE
Release 0.7.29; Make code_saving_enabled configurable in mock_server.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.7.28",
+    version="0.7.29",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         "Flask",
         "requests",
-        "yea==0.7.9",
+        "yea==0.7.10",
     ],
     package_dir={"": "src"},
     entry_points={
@@ -23,5 +23,5 @@ setup(
     zip_safe=False,
     include_package_data=True,
     license="MIT license",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
 )

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -84,6 +84,7 @@ def default_ctx():
         "used_artifact_info": None,
         "invalid_launch_spec_project": False,
         "n_sweep_runs": 0,
+        "code_saving_enabled": True,
     }
 
 
@@ -564,11 +565,15 @@ def create_app(user_ctx=None):
                         "admin": False,
                         "email": "mock@server.test",
                         "username": "mock",
-                        "flags": '{"code_saving_enabled": true}',
                         "teams": {"edges": []},  # TODO make configurable for cli_test
                     },
                 },
             }
+            code_saving_enabled = ctx.get("code_saving_enabled")
+            if code_saving_enabled is not None:
+                viewer_dict["data"]["viewer"][
+                    "flags"
+                ] = f'{{"code_saving_enabled": {str(code_saving_enabled).lower()}}}'
             server_info = {
                 "serverInfo": {
                     "cliVersionInfo": {

--- a/src/yea_wandb/plugin.py
+++ b/src/yea_wandb/plugin.py
@@ -2,6 +2,7 @@
 
 import pprint
 import re
+from typing import Any, Dict, Optional
 
 from yea_wandb import backend
 
@@ -227,6 +228,14 @@ class YeaWandbPlugin:
 
     def monitors_start(self):
         self._backend.start()
+
+    def monitors_configure(self, config: Optional[Dict[str, Any]]):
+        if config is None:
+            return
+        # optionally configure backend (update context)
+        ctx = config.get("mock_server")
+        if ctx is not None:
+            self._backend.update_ctx(ctx)
 
     def monitors_stop(self):
         self._backend.stop()

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -1,11 +1,10 @@
-
 import os
 import pytest
-import yaml
 
 from yea import ytest
 from yea import context
 from yea_wandb import plugin
+
 
 @pytest.fixture
 def check_state_fn():


### PR DESCRIPTION
This comes from https://github.com/wandb/client/pull/3083 and is needed for a test there.
Accompanies (and depends on) https://github.com/wandb/yea/pull/12.