### PR TITLE
GitHub Action to check if mocks are synced with wandb/client:master

### DIFF
--- a/.github/workflows/are-mocks-synced.yml
+++ b/.github/workflows/are-mocks-synced.yml
@@ -1,10 +1,5 @@
 name: are-mocks-synced
 
-defaults:
-  run:
-    # run shell in interactive mode
-    shell: bash -ieo pipefail {0}
-
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/are-mocks-synced.yml
+++ b/.github/workflows/are-mocks-synced.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   are-mocks-synced:

--- a/.github/workflows/are-mocks-synced.yml
+++ b/.github/workflows/are-mocks-synced.yml
@@ -2,6 +2,8 @@ name: check if mocks are synced
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/are-mocks-synced.yml
+++ b/.github/workflows/are-mocks-synced.yml
@@ -24,6 +24,15 @@ jobs:
           wget https://raw.githubusercontent.com/wandb/client/master/tests/utils/mock_server.py
           diff mock_server.py src/yea_wandb/mock_server.py
         continue-on-error: true
+      - name: Check if artifact_emu is up to date with wandb/client:master
+        id: artifact_emu
+        run: |
+          wget https://raw.githubusercontent.com/wandb/client/master/tests/utils/artifact_emu.py
+          diff artifact_emu.py src/yea_wandb/artifact_emu.py
+        continue-on-error: true
       - name: Check on failures
-        if: steps.mock_requests.outcome != 'success' || steps.mock_server.outcome != 'success'
+        if: |
+          steps.mock_requests.outcome != 'success'
+          || steps.mock_server.outcome != 'success'
+          || steps.artifact_emu.outcome != 'success'
         run: exit 1

--- a/.github/workflows/are-mocks-synced.yml
+++ b/.github/workflows/are-mocks-synced.yml
@@ -1,8 +1,7 @@
-name: are-mocks-synced
+name: check if mocks are synced
 
 on:
   push:
-    branches: [ master ]
   pull_request:
 
 jobs:

--- a/.github/workflows/are-mocks-synced.yml
+++ b/.github/workflows/are-mocks-synced.yml
@@ -1,0 +1,34 @@
+name: are-mocks-synced
+
+defaults:
+  run:
+    # run shell in interactive mode
+    shell: bash -ieo pipefail {0}
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  are-mocks-synced:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check if mock_requests is up to date with wandb/client:master
+        id: mock_requests
+        run: |
+          wget https://raw.githubusercontent.com/wandb/client/master/tests/utils/mock_requests.py
+          diff mock_requests.py src/yea_wandb/mock_requests.py
+        continue-on-error: true
+      - name: Check if mock_server is up to date with wandb/client:master
+        id: mock_server
+        run: |
+          wget https://raw.githubusercontent.com/wandb/client/master/tests/utils/mock_server.py
+          diff mock_server.py src/yea_wandb/mock_server.py
+        continue-on-error: true
+      - name: Check on failures
+        if: steps.mock_requests.outcome != 'success' || steps.mock_server.outcome != 'success'
+        run: exit 1

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -10,6 +10,8 @@ import platform
 import yaml
 import six
 
+TEST_GA = None
+
 # HACK: restore first two entries of sys path after wandb load
 save_path = sys.path[:2]
 import wandb

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -10,8 +10,6 @@ import platform
 import yaml
 import six
 
-TEST_GA = None
-
 # HACK: restore first two entries of sys path after wandb load
 save_path = sys.path[:2]
 import wandb


### PR DESCRIPTION
Tested this by screwing up `mock_server.py` -- it works (see https://github.com/wandb/yea-wandb/pull/39/commits/0c6d6840550cf14dda7027311304d8c03ecb9aa8).