### PR TITLE
Update mock_server.py + version++

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.7.33",
+    version="0.7.34",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -66,7 +66,7 @@ def default_ctx():
         "run_queues": {"1": []},
         "num_popped": 0,
         "num_acked": 0,
-        "max_cli_version": "0.12.0",
+        "max_cli_version": "0.13.0",
         "runs": {},
         "run_ids": [],
         "file_names": [],


### PR DESCRIPTION
The client is at `0.12.11` already, so upped it to `0.13.0` for now.
I have the corresponding change in the client in this PR: https://github.com/wandb/client/pull/3236