### PR TITLE
linkArtifact endpoint + state change to include portfolio_links dict

### DIFF
--- a/src/yea_wandb/artifact_emu.py
+++ b/src/yea_wandb/artifact_emu.py
@@ -9,6 +9,7 @@ class ArtifactEmulator:
         self._artifacts_by_id = {}
         self._files = {}
         self._base_url = base_url
+        self._portfolio_links = {}
 
     def create(self, variables):
         collection_name = variables["artifactCollectionNames"][0]
@@ -58,6 +59,31 @@ class ArtifactEmulator:
         if art_type:
             self._ctx["artifacts_created"][collection_name]["type"] = art_type
 
+        return response
+
+    def link(self, variables):
+        pfolio_name = variables.get("artifactPortfolioName")
+        artifact_id = variables.get("artifactID")
+        if artifact_id is None:
+            artifact_id = variables.get("clientID")
+        aliases = variables.get("aliases")
+        # TODO: assert artifact exists in our _artifacts_by_id, if not change response
+        
+        art = {
+            "id": artifact_id,
+            "aliases": [a["alias"] for a in aliases]
+        }
+
+        # We automatically create a portfolio for the user if we can't find the one given. 
+        links = self._portfolio_links.setdefault(pfolio_name, [])
+        if not any(map(lambda x: artifact_id == x["id"], links)):
+            links.append(art)
+
+        self._ctx["portfolio_links"].setdefault(pfolio_name, {})
+        self._ctx["portfolio_links"][pfolio_name]["num"] = len(links)
+        num = self._ctx["portfolio_links"][pfolio_name]["num"]
+
+        response = {"data": {"linkArtifact": {"versionIndex": num-1}}}
         return response
 
     def create_files(self, variables):

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -61,6 +61,7 @@ def default_ctx():
         "artifacts": {},
         "artifacts_by_id": {},
         "artifacts_created": {},
+        "portfolio_links": {},
         "upsert_bucket_count": 0,
         "out_of_date": False,
         "empty_query": False,
@@ -1006,6 +1007,9 @@ def create_app(user_ctx=None):
                     }
                 )
             return json.dumps({"data": {"prepareFiles": {"files": {"edges": nodes}}}})
+        if "mutation LinkArtifact(" in body["query"]:
+            if ART_EMU:
+                return ART_EMU.link(variables=body["variables"])
         if "mutation CreateArtifact(" in body["query"]:
             if ART_EMU:
                 return ART_EMU.create(variables=body["variables"])
@@ -2161,6 +2165,10 @@ class ParseCTX(object):
     @property
     def artifacts(self):
         return self._ctx.get("artifacts_created") or {}
+
+    @property
+    def portfolio_links(self):
+        return self._ctx.get("portfolio_links") or {}
 
     @property
     def tags(self):

--- a/src/yea_wandb/plugin.py
+++ b/src/yea_wandb/plugin.py
@@ -285,6 +285,7 @@ class YeaWandbPlugin:
             runs.append(run)
 
         state[":wandb:artifacts"] = glob_parsed.artifacts
+        state[":wandb:portfolio_links"] = glob_parsed.portfolio_links
         state[":wandb:sentry_events"] = glob_parsed.sentry_events
         state[":wandb:runs"] = runs
         # deprecate this


### PR DESCRIPTION
This PR provides a way to test `run.link_model` (and subsequently `run.link_artifact`). It adds an endpoint and handling logic to mock_server and the artifact emulator. 