### PR TITLE
Make remote base url configurable in relay mode

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.52
+current_version = 0.7.53-dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.7.52",
+    version="0.7.53-dev",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/src/yea_wandb/__init__.py
+++ b/src/yea_wandb/__init__.py
@@ -2,4 +2,4 @@ from .setup import setup
 
 
 __all__ = ["setup"]
-__version__ = "0.7.52"
+__version__ = "0.7.53-dev"

--- a/src/yea_wandb/backend.py
+++ b/src/yea_wandb/backend.py
@@ -75,9 +75,6 @@ class Backend:
         if mockserver_host == "__auto__":
             mockserver_host = self._get_ip()
 
-        # with open("/Users/dimaduev/dev/client/2.txt", "w") as f:
-        #     f.write(f"{mockserver_host}")
-
         root = os.path.abspath(os.path.join(os.path.dirname(__file__)))
         path = os.path.join(root, "mock_server.py")
         command = [sys.executable, "-u", path, "--yea"]

--- a/src/yea_wandb/backend.py
+++ b/src/yea_wandb/backend.py
@@ -65,7 +65,9 @@ class Backend:
         mockserver_bind = self._params["mockserver-bind"]
         mockserver_host = self._params["mockserver-host"]
         mockserver_relay = self._params["mockserver-relay"]
-        mockserver_relay_remote_base_url = self._params["mockserver-relay-remote-base-url"]
+        mockserver_relay_remote_base_url = self._params[
+            "mockserver-relay-remote-base-url"
+        ]
         # TODO: consolidate with github.com/wandb/client:tests/conftest.py
         port = self._free_port(mockserver_bind)
 
@@ -137,9 +139,7 @@ class Backend:
                 else:
                     raise ValueError("Server failed to start.")
         if started:
-            print(
-                f"INFO: Mock server listing on {server._port}, see {logfname}"
-            )
+            print(f"INFO: Mock server listing on {server._port}, see {logfname}")
         else:
             server.terminate()
             print(f"ERROR: Server failed to launch, see {logfname}")

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -1,27 +1,28 @@
 """Mock Server for simple calls the cli and public api make"""
 
-from flask import Flask, request, g, jsonify
-import os
-import sys
-import re
 from datetime import datetime, timedelta
-import json
-import platform
-import yaml
-import gzip
 import functools
+import gzip
+import json
+import logging
+import os
+import platform
+import re
+import sys
+import threading
 import time
+import urllib.parse
+
+from flask import Flask, request, g, jsonify
 import requests
 from werkzeug.exceptions import BadRequest
+import yaml
 
 # HACK: restore first two entries of sys path after wandb load
 save_path = sys.path[:2]
 import wandb
 
 sys.path[0:0] = save_path
-import logging
-import urllib
-import threading
 
 RequestsMock = None
 InjectRequestsParse = None
@@ -381,7 +382,12 @@ class SnoopRelay:
                 url_path = request.path
                 body = request.get_json()
 
-                url = f"https://api.wandb.ai{url_path}"
+                base_url = os.environ.get(
+                    "MOCKSERVER_RELAY_REMOTE_BASE_URL",
+                    "https://api.wandb.ai",
+                )
+                url = urllib.parse.urljoin(base_url, url_path)
+
                 resp = requests.post(url, json=body)
                 data = resp.json()
                 run_obj = data.get("data", {}).get("upsertBucket", {}).get("bucket", {})
@@ -408,7 +414,7 @@ class SnoopRelay:
                         time.sleep(12)
                         raise HttpException("some error", status_code=500)
                 return data
-            assert False
+            assert False  # todo: why is this here, Jeff?
 
             return func(*args, **kwargs)
 
@@ -431,10 +437,16 @@ class SnoopRelay:
 
             # TODO: handle errors better
             try:
-                # NOTE: We are using wandb, but it isn't a strict dependency
                 import wandb
 
-                api = wandb.Api()
+                api = wandb.Api(
+                    overrides={
+                        "base_url": os.environ.get(
+                            "MOCKSERVER_RELAY_REMOTE_BASE_URL",
+                            "https://api.wandb.ai",
+                        )
+                    }
+                )
                 run = api.run(f"{run_info['entity']}/{run_info['project']}/{run_id}")
             except Exception as e:
                 print(f"ERROR: problem calling public api for run {run_id}", e)
@@ -497,7 +509,7 @@ def create_app(user_ctx=None):
             ctx = snoop.context_enrich(ctx)
             return json.dumps(ctx)
         elif request.method == "DELETE":
-            app.logger.info("reseting context")
+            app.logger.info("resetting context")
             set_ctx(default_ctx())
             return json.dumps(get_ctx())
         else:

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -414,7 +414,7 @@ class SnoopRelay:
                         time.sleep(12)
                         raise HttpException("some error", status_code=500)
                 return data
-            assert False  # todo: why is this here, Jeff?
+            assert False  # we do not support get requests yet, and likely never will :)
 
             return func(*args, **kwargs)
 


### PR DESCRIPTION
In this PR:

- Make the remote base url configurable in relay mode with something like:
```
WANDB_API_KEY=<API_KEY> \
  yea --debug \
  -p wandb:mockserver-relay=true \
  -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai \
  run basic.py
```
so that you can point it at e.g. a local instance.
- Bump version to dev