### PR TITLE
Add stats

### DIFF
--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -2171,6 +2171,12 @@ class ParseCTX:
         return history
 
     @property
+    def stats(self):
+        fs_files = self.get_filestream_file_items()
+        stats = fs_files.get("wandb-events.jsonl")
+        return stats
+
+    @property
     def output(self):
         fs_files = self.get_filestream_file_items()
         output_items = fs_files.get("output.log", [])

--- a/src/yea_wandb/plugin.py
+++ b/src/yea_wandb/plugin.py
@@ -276,6 +276,7 @@ class YeaWandbPlugin:
             run["summary_wandb"] = parsed.summary_wandb
             run["telemetry"] = parsed.telemetry
             run["metrics"] = parsed.metrics
+            run["stats"] = parsed.stats
             run["exitcode"] = parsed.exit_code
             run["files"] = parsed.files
             run["output"] = parsed.output


### PR DESCRIPTION
At stats logger to yea

Here is an example of the debug output now:
```
                    'run_id': '2e9pjn37',
                     'stats': [ { '_runtime': 3,
                                  '_timestamp': 1655774688,
                                  '_wandb': True,
                                  'system.cpu': 18.25,
                                  'system.disk': 9.3,
                                  'system.gpu.0.gpu': 14.5,
                                  'system.gpu.0.memoryAllocated': 16.65,
```