### PR TITLE
Fix run queue item ids to string type

### DIFF
--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -1495,7 +1495,7 @@ def create_app(user_ctx=None):
                                             {
                                                 "node": {
                                                     "id": "1",
-                                                    "associatedRunId": "1",
+                                                    "associatedRunId": "test",
                                                     "state": "CLAIMED",
                                                 }
                                             }
@@ -1546,7 +1546,7 @@ def create_app(user_ctx=None):
                     {
                         "data": {
                             "popFromRunQueue": {
-                                "runQueueItemId": 1,
+                                "runQueueItemId": "1",
                                 "runSpec": {
                                     "uri": "https://wandb.ai/mock_server_entity/test_project/runs/1",
                                     "project": "test_project2",
@@ -1561,7 +1561,7 @@ def create_app(user_ctx=None):
                 {
                     "data": {
                         "popFromRunQueue": {
-                            "runQueueItemId": 1,
+                            "runQueueItemId": "1",
                             "runSpec": {
                                 "uri": "https://wandb.ai/mock_server_entity/test_project/runs/1",
                                 "project": "test_project",
@@ -1581,7 +1581,7 @@ def create_app(user_ctx=None):
                 ctx["run_queues"][body["variables"]["queueID"]] = [
                     body["variables"]["queueID"]
                 ]
-            return json.dumps({"data": {"pushToRunQueue": {"runQueueItemId": 1}}})
+            return json.dumps({"data": {"pushToRunQueue": {"runQueueItemId": "1"}}})
         if "mutation ackRunQueueItem" in body["query"]:
             ctx["num_acked"] += 1
             return json.dumps({"data": {"ackRunQueueItem": {"success": True}}})


### PR DESCRIPTION
There were some issues from returning ints as the id type for run queue items. Since we expect a string, this just corrects all of them to strings.