### PR TITLE
Pin flask.. new release is causing dependency issues and flake for imports5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.7-dev
+current_version = 0.8.7
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.6
+current_version = 0.8.7-dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.8.7-dev",
+    version="0.8.7",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[
-        "Flask",
+        "Flask<2.2.0",
         "requests",
         "yea==0.8.3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.8.6",
+    version="0.8.7-dev",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/src/yea_wandb/__init__.py
+++ b/src/yea_wandb/__init__.py
@@ -2,4 +2,4 @@ from .setup import setup
 
 
 __all__ = ["setup"]
-__version__ = "0.8.7-dev"
+__version__ = "0.8.7"

--- a/src/yea_wandb/__init__.py
+++ b/src/yea_wandb/__init__.py
@@ -2,4 +2,4 @@ from .setup import setup
 
 
 __all__ = ["setup"]
-__version__ = "0.8.6"
+__version__ = "0.8.7-dev"


### PR DESCRIPTION
History:
https://pypi.org/project/Flask/2.2.1/#history

actually not sure the dependency is coming from yea-wandb.. but it is likely the culprit

```
flask 2.2.1 requires Werkzeug>=2.2.0, but you have werkzeug 2.0.2 which is incompatible.
```

Error:
``` 
File "/mnt/ramdisk/.tox/func-s_imports5-py37/lib/python3.7/site-packages/flask/__init__.py", line 4, in <module>
    from . import json as json
  File "/mnt/ramdisk/.tox/func-s_imports5-py37/lib/python3.7/site-packages/flask/json/__init__.py", line 8, in <module>
    from ..globals import current_app
  File "/mnt/ramdisk/.tox/func-s_imports5-py37/lib/python3.7/site-packages/flask/globals.py", line 57, in <module>
    _cv_app, unbound_message=_no_app_msg
TypeError: __init__() got an unexpected keyword argument 'unbound_message'
```