### PR TITLE
update mock_sever

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.6-dev
+current_version = 0.9.6
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.5
+current_version = 0.9.6-dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.9.5",
+    version="0.9.6-dev",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="yea-wandb",
-    version="0.9.6-dev",
+    version="0.9.6",
     description="Test harness wandb plugin",
     packages=["yea_wandb"],
     install_requires=[

--- a/src/yea_wandb/__init__.py
+++ b/src/yea_wandb/__init__.py
@@ -1,4 +1,4 @@
 from .setup import setup
 
 __all__ = ["setup"]
-__version__ = "0.9.6-dev"
+__version__ = "0.9.6"

--- a/src/yea_wandb/__init__.py
+++ b/src/yea_wandb/__init__.py
@@ -1,4 +1,4 @@
 from .setup import setup
 
 __all__ = ["setup"]
-__version__ = "0.9.5"
+__version__ = "0.9.6-dev"

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -114,7 +114,10 @@ def mock_server(mocker):
     mock = RequestsMock(app, ctx)
     # We mock out all requests libraries, couldn't find a way to mock the core lib
     sdk_path = "wandb.sdk"
-    mocker.patch("wandb.sdk.lib.gql_request.requests.Session", mock)
+    # From previous wandb_gql transport library.
+    mocker.patch("wandb_gql.transport.requests.requests", mock)
+
+    mocker.patch("wandb.wandb_sdk.lib.gql_request.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.file_stream.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.internal_api.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.update.requests", mock)
@@ -372,7 +375,6 @@ class HttpException(Exception):
 
 
 class SnoopRelay:
-
     _inject_count: int
     _inject_time: float
 
@@ -383,7 +385,6 @@ class SnoopRelay:
     def relay(self, func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-
             # Normal mockserver mode, disable live relay and call next function
             if not os.environ.get("MOCKSERVER_RELAY"):
                 return func(*args, **kwargs)
@@ -1659,7 +1660,6 @@ def create_app(user_ctx=None):
                 c["alerts"].append(adict)
             return {"data": {"notifyScriptableRunAlert": {"success": True}}}
         if "query SearchUsers" in body["query"]:
-
             return {
                 "data": {
                     "users": {

--- a/src/yea_wandb/mock_server.py
+++ b/src/yea_wandb/mock_server.py
@@ -114,7 +114,7 @@ def mock_server(mocker):
     mock = RequestsMock(app, ctx)
     # We mock out all requests libraries, couldn't find a way to mock the core lib
     sdk_path = "wandb.sdk"
-    mocker.patch("wandb_gql.transport.requests.requests", mock)
+    mocker.patch("wandb.sdk.lib.gql_request.requests.Session", mock)
     mocker.patch("wandb.wandb_sdk.internal.file_stream.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.internal_api.requests", mock)
     mocker.patch("wandb.wandb_sdk.internal.update.requests", mock)


### PR DESCRIPTION
Needs another mock for https://github.com/wandb/wandb/pull/5075, which uses a `requests.Session` object instead of making new `requests.request` calls, and also moves code into `sdk.lib` that was previously vendored.

The matching PR to merge into `wandb` is https://github.com/wandb/wandb/pull/5177 as soon as this release is pushed.